### PR TITLE
Remove a warning message about unused variable

### DIFF
--- a/lib/socksify.rb
+++ b/lib/socksify.rb
@@ -330,7 +330,7 @@ module Socksify
       end
       s.write [0].pack('n')  # Port
       
-      addr, port = s.socks_receive_reply
+      addr, _port = s.socks_receive_reply
       Socksify::debug_notice "Resolved #{host} as #{addr} over SOCKS"
       addr
     ensure


### PR DESCRIPTION
... the following warning:

socksify-1.6.0/lib/socksify.rb:333: warning: assigned but unused variable - port