### PR TITLE
Fix debug output when debug=false

### DIFF
--- a/lib/socksify/debug.rb
+++ b/lib/socksify/debug.rb
@@ -44,7 +44,7 @@ module Socksify
   private
 
   def self.debug(color, str)
-    if defined? @@debug
+    if @@debug
       puts "#{color}#{now_s}#{Color::Reset} #{str}"
     end
   end


### PR DESCRIPTION
This PR will fix the debug output bug, caused by wrongly evaluating `@@debug`.

When explicitly setting `Socksify.debug = false` the `@@debug` class variable is wrongly evaluated in `Socksify`, causing an explicit `false` assignment to send strings to the output buffer. Undefined class variables will automatically yield false.
