### PR TITLE
Net::HTTP.SOCKSProxy auth support, take 2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -73,3 +73,5 @@ SOCKSify Ruby 1.7.2
 * Fix Socksify::debug = false
   Previously, debug was enabled if any value was assigned to Socksify::debug
   (thanks to Dennis Blommesteijn)
+* Authentication support added to Net::HTTP.SOCKSProxy
+  (thanks to @ojab)

--- a/doc/index.html
+++ b/doc/index.html
@@ -99,6 +99,14 @@ end
 	explicitly or use <code>Net::HTTP</code> directly.
       </p>
 
+      <p>
+	<code>Net::HTTP.SOCKSProxy</code> also supports SOCKS authentication:
+      </p>
+      <pre>
+Net::HTTP.SOCKSProxy('127.0.0.1', 9050, 'username', 'p4ssw0rd')
+      </pre>
+
+
       <h3>Resolve addresses via SOCKS</h3>
       <pre>Socksify::resolve("spaceboyz.net")
 # => "87.106.131.203"</pre>

--- a/lib/socksify/http.rb
+++ b/lib/socksify/http.rb
@@ -21,7 +21,7 @@ require 'net/http'
 
 module Net
   class HTTP
-    def self.SOCKSProxy(p_host, p_port)
+    def self.SOCKSProxy(p_host, p_port, p_username = nil, p_password = nil)
       delta = SOCKSProxyDelta
       proxyclass = Class.new(self)
       proxyclass.send(:include, delta)
@@ -30,6 +30,8 @@ module Net
         extend delta::ClassMethods
         @socks_server = p_host
         @socks_port = p_port
+        @socks_username = p_username
+        @socks_password = p_password
       }
       proxyclass
     end
@@ -43,16 +45,24 @@ module Net
         def socks_port
           @socks_port
         end
+
+        def socks_username
+          @socks_username
+        end
+
+        def socks_password
+          @socks_password
+        end
       end
 
       module InstanceMethods
         if RUBY_VERSION[0..0] >= '2'
           def address
-            TCPSocket::SOCKSConnectionPeerAddress.new(self.class.socks_server, self.class.socks_port, @address)
+            TCPSocket::SOCKSConnectionPeerAddress.new(self.class.socks_server, self.class.socks_port, @address, self.class.socks_username, self.class.socks_password)
           end
         else
           def conn_address
-            TCPSocket::SOCKSConnectionPeerAddress.new(self.class.socks_server, self.class.socks_port, address())
+            TCPSocket::SOCKSConnectionPeerAddress.new(self.class.socks_server, self.class.socks_port, address(), self.class.socks_username, self.class.socks_password)
           end
         end
       end

--- a/test/tc_socksify.rb
+++ b/test/tc_socksify.rb
@@ -130,7 +130,7 @@ class SocksifyTest < Test::Unit::TestCase
   end
 
   def internet_yandex_com_ip(http_klass = Net::HTTP)
-    parse_internet_yandex_com_response get_http(http_klass, 'https://213.180.204.62/internet', 'yandex.com') # "http://yandex.com/internet"
+    parse_internet_yandex_com_response get_http(http_klass, 'https://213.180.204.62/internet/', 'yandex.com') # "http://yandex.com/internet"
   end
 
   def parse_check_response(body)
@@ -151,7 +151,7 @@ class SocksifyTest < Test::Unit::TestCase
   end
 
   def parse_internet_yandex_com_response(body)
-    if body =~ /<strong>IP-[^<]*<\/strong>: (\d+\.\d+\.\d+\.\d+)/
+    if body =~ /<strong>IPv4 address<\/strong>: <span[^>]*>(\d+\.\d+\.\d+\.\d+)/
       ip = $1
     else
       raise 'Bogus response, no IP'+"\n"+body.inspect


### PR DESCRIPTION
This MR is inspired by #24, but does not use thread-local variables to store username/password. This is IMO safest and cleanest way to do it.