### PR TITLE
Drop unused gemspec directive rubyforge_project

### DIFF
--- a/socksify.gemspec
+++ b/socksify.gemspec
@@ -10,7 +10,6 @@ spec = Gem::Specification.new do |s|
   s.licenses = ['Ruby', 'GPL-3.0']
   s.email = "stephan@spaceboyz.net"
   s.homepage = "http://socksify.rubyforge.org/"
-  s.rubyforge_project = 'socksify'
   s.files = %w{COPYING}
   s.files += Dir.glob("lib/**/*")
   s.files += Dir.glob("bin/**/*")


### PR DESCRIPTION
The Rubyforge website is no longer. This removes a now-unsupported directive.

The homepage could change, but this commit does nothing about that.