### PR TITLE
fix required_ruby_version

### DIFF
--- a/socksify.gemspec
+++ b/socksify.gemspec
@@ -2,22 +2,21 @@
 
 require 'rubygems'
 
-spec = Gem::Specification.new do |s|
+Gem::Specification.new do |s|
   s.name = 'socksify'
   s.version = "1.7.1"
   s.summary = "Redirect all TCPSockets through a SOCKS5 proxy"
   s.authors = ["Stephan Maka", "Andrey Kouznetsov", "Christopher Thorpe", "Musy Bite", "Yuichi Tateno", "David Dollar"]
   s.licenses = ['Ruby', 'GPL-3.0']
+  s.required_ruby_version = ['>= 2.0', '< 3.1']
   s.email = "stephan@spaceboyz.net"
-  s.homepage = "http://socksify.rubyforge.org/"
-  s.rubyforge_project = 'socksify'
-  s.files = %w{COPYING}
+  s.homepage = "https://github.com/astro/socksify-ruby"
+  s.files = %w[COPYING]
   s.files += Dir.glob("lib/**/*")
   s.files += Dir.glob("bin/**/*")
   s.files += Dir.glob("doc/**/*")
-  s.files = s.files.delete_if { |f| f =~ /\~$/ }
+  s.files = s.files.delete_if { |f| f =~ /~$/ }
   s.require_path = 'lib'
-  s.executables = %w{socksify_ruby}
-  s.has_rdoc = false
-  s.extra_rdoc_files = Dir.glob("doc/**/*") + %w{COPYING}
+  s.executables = %w[socksify_ruby]
+  s.extra_rdoc_files = Dir.glob("doc/**/*") + %w[COPYING]
 end

--- a/test/tc_socksify.rb
+++ b/test/tc_socksify.rb
@@ -151,7 +151,8 @@ class SocksifyTest < Test::Unit::TestCase
   end
 
   def parse_internet_yandex_com_response(body)
-    if body =~ /<strong>IP-[^<]*<\/strong>: (\d+\.\d+\.\d+\.\d+)/
+    # if body =~ /<strong>IP-[^<]*<\/strong>: (\d+\.\d+\.\d+\.\d+)/
+    if body =~ /<div>(\d+\.\d+\.\d+\.\d+)<\/div>/
       ip = $1
     else
       raise 'Bogus response, no IP'+"\n"+body.inspect
@@ -172,7 +173,7 @@ class SocksifyTest < Test::Unit::TestCase
   def test_resolve_reverse
     enable_socks
 
-    assert_equal("google-public-dns-a.google.com", Socksify::resolve("8.8.8.8"))
+    assert_equal("dns.google", Socksify::resolve("8.8.8.8"))
 
     assert_raise SOCKSError::HostUnreachable do
       Socksify::resolve("0.0.0.0")


### PR DESCRIPTION
Fixed tests, specified `required_ruby_version` = ['>= 2.0', '< 3.1'] as tests fail in 3.1