### PR TITLE
Fix tcp socket with connect timeout

### DIFF
--- a/lib/socksify/tcpsocket.rb
+++ b/lib/socksify/tcpsocket.rb
@@ -17,7 +17,7 @@ class TCPSocket
     socks_ignores = set_socks_ignores(socks_peer)
     host = socks_peer.peer_host if socks_peer
     if socks_server && socks_port && !socks_ignores.include?(host)
-      make_socks_connection(host, port, socks_server, socks_port)
+      make_socks_connection(host, port, socks_server, socks_port, **kwargs)
     else
       make_direct_connection(host, port, local_host, local_port, **kwargs)
     end
@@ -57,9 +57,9 @@ class TCPSocket
     socks_peer ? [] : self.class.socks_ignores
   end
 
-  def make_socks_connection(host, port, socks_server, socks_port)
+  def make_socks_connection(host, port, socks_server, socks_port, **kwargs)
     Socksify.debug_notice "Connecting to SOCKS server #{socks_server}:#{socks_port}"
-    initialize_tcp socks_server, socks_port
+    initialize_tcp socks_server, socks_port, **kwargs
     socks_authenticate unless @socks_version =~ /^4/
     socks_connect(host, port) if host
   end

--- a/lib/socksify/tcpsocket.rb
+++ b/lib/socksify/tcpsocket.rb
@@ -10,7 +10,7 @@ class TCPSocket
 
   # See http://tools.ietf.org/html/rfc1928
   # rubocop:disable Metrics/ParameterLists
-  def initialize(host = nil, port = nil, local_host = nil, local_port = nil)
+  def initialize(host = nil, port = nil, local_host = nil, local_port = nil, **kwargs)
     socks_peer = host if host.is_a?(SOCKSConnectionPeerAddress)
     socks_server = set_socks_server(socks_peer)
     socks_port = set_socks_port(socks_peer)
@@ -19,7 +19,7 @@ class TCPSocket
     if socks_server && socks_port && !socks_ignores.include?(host)
       make_socks_connection(host, port, socks_server, socks_port)
     else
-      make_direct_connection(host, port, local_host, local_port)
+      make_direct_connection(host, port, local_host, local_port, **kwargs)
     end
   end
   # rubocop:enable Metrics/ParameterLists
@@ -64,9 +64,9 @@ class TCPSocket
     socks_connect(host, port) if host
   end
 
-  def make_direct_connection(host, port, local_host, local_port)
+  def make_direct_connection(host, port, local_host, local_port, **kwargs)
     Socksify.debug_notice "Connecting directly to #{host}:#{port}"
-    initialize_tcp host, port, local_host, local_port
+    initialize_tcp host, port, local_host, local_port, **kwargs
     Socksify.debug_debug "Connected to #{host}:#{port}"
   end
 end

--- a/test/test_tcp_socket.rb
+++ b/test/test_tcp_socket.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+class TCPSocketTest < Minitest::Test
+  include HelperMethods
+
+  if RUBY_VERSION.to_f >= 3.0
+    def test_tcp_socket_direct_connection_with_connection_timeout
+      socket = TCPSocket.new('127.0.0.1', 9050, connect_timeout: 0.1)
+
+      assert !socket.closed?
+    end
+  end
+end

--- a/test/test_tcpsocket.rb
+++ b/test/test_tcpsocket.rb
@@ -12,4 +12,10 @@ class TCPSocketTest < Minitest::Test
       assert !socket.closed?
     end
   end
+
+  def test_tcp_socket_direct_connection_with_connection_timeout
+    socket = TCPSocket.new('127.0.0.1', 9050)
+
+    assert !socket.closed?
+  end
 end

--- a/test/test_tcpsocket.rb
+++ b/test/test_tcpsocket.rb
@@ -7,13 +7,26 @@ class TCPSocketTest < Minitest::Test
 
   if RUBY_VERSION.to_f >= 3.0
     def test_tcp_socket_direct_connection_with_connection_timeout
+      disable_socks
+
       socket = TCPSocket.new('127.0.0.1', 9050, connect_timeout: 0.1)
+
+      assert !socket.closed?
+    end
+
+    def test_tcp_socket_socks_connection_with_connection_timeout
+      enable_socks
+
+      # leave off the host because we don't need to worry about connecting to socks
+      socket = TCPSocket.new(connect_timeout: 0.1)
 
       assert !socket.closed?
     end
   end
 
-  def test_tcp_socket_direct_connection_with_connection_timeout
+  def test_tcp_socket_direct_connection_with_connection_timeout_no_kwargs
+    disable_socks
+
     socket = TCPSocket.new('127.0.0.1', 9050)
 
     assert !socket.closed?


### PR DESCRIPTION
This library doesn't fully work with Ruby versions > 3

The [TCPSocket class ](https://ruby-doc.org/stdlib-3.0.0/libdoc/socket/rdoc/TCPSocket.html) in ruby 3.0.0 and up has an optional keyword argument to specify a connection timeout.  Another library we were using was passing a `connect_timeout` to the TCPSocket initializer.  Because this library monkey patches the initializer and then doesn't allow for additional keyword arguments the `connect_timeout` argument was getting turned into a  hash and passed as the `local_host` argument which caused exceptions.

The test (without the code changes in `tcpsocket` replicates the errors it could cause. 

This change allows for keyword arguments so that a `connect_timeout` can be passed.