### PR TITLE
Add funding_uri to gemspec

### DIFF
--- a/socksify.gemspec
+++ b/socksify.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.executables = %w[socksify_ruby]
   s.extra_rdoc_files = Dir.glob('doc/**/*') + %w[COPYING]
+  s.metadata["funding_uri"] = "https://github.com/sponsors/astro"
 end


### PR DESCRIPTION
I noticed that you are on github sponsors. This PR adds the `funding_uri` to your gemspec to help increase visibility using the `bundle fund` command in Bundler.