### PR TITLE
Net http socksproxy with auth

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,17 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+
+    services:
+      services:
+        socks5:
+          image: serjs/go-socks5-proxy
+          env:
+            PROXY_USER: user
+            PROXY_PASSWORD: password
+          ports:
+            - 1080:1080
+
     strategy:
       matrix:
         ruby: ['3.1', '3.2', '3.3', head]

--- a/ChangeLog
+++ b/ChangeLog
@@ -81,3 +81,5 @@ SOCKSify Ruby 1.7.3
 ===================
 * add Rakefile
 * fix missing :timeout kwarg in TCPSocket class (thanks @lizzypy)
+* Authentication support added to Net::HTTP.SOCKSProxy
+  (thanks to @ojab)

--- a/ChangeLog
+++ b/ChangeLog
@@ -82,4 +82,4 @@ SOCKSify Ruby 1.7.3
 * add Rakefile
 * fix missing :timeout kwarg in TCPSocket class (thanks @lizzypy)
 * Authentication support added to Net::HTTP.SOCKSProxy
-  (thanks to @ojab)
+  (thanks to @ojab and @anton-smagin)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ Socksify.resolve("spaceboyz.net")
 ```
 ### Testing and Debugging
 
-A tor proxy is required before running the tests. Install tor from your usual package manager, check it is running with `pidof tor` then run the tests with:
+A tor proxy and socks5 proxy with auth is required before running the tests. 
+* Install tor from your usual package manager, check it is running with `pidof tor` then run the tests with:
+* Start a SOCKS5 proxy using Docker `docker run -d --name socks5 -p 1080:1080 -e PROXY_USER=user -e PROXY_PASSWORD=password serjs/go-socks5-proxy`
 
 `bundle exec rake`
 

--- a/doc/index.html
+++ b/doc/index.html
@@ -105,6 +105,14 @@ end
 	explicitly or use <code>Net::HTTP</code> directly.
       </p>
 
+      <p>
+	<code>Net::HTTP.SOCKSProxy</code> also supports SOCKS authentication:
+      </p>
+      <pre>
+Net::HTTP.SOCKSProxy('127.0.0.1', 9050, 'username', 'p4ssw0rd')
+      </pre>
+
+
       <h3>Resolve addresses via SOCKS</h3>
       <pre>Socksify::resolve("spaceboyz.net")
 # => "87.106.131.203"</pre>

--- a/lib/socksify/http.rb
+++ b/lib/socksify/http.rb
@@ -22,8 +22,6 @@ module Net
   # patched class
   class HTTP
     def self.socks_proxy(p_host, p_port, p_username = nil, p_password = nil)
-      proxyclass = Class.new(self)
-      proxyclass.send(:include, SOCKSProxyDelta)
       proxyclass.module_eval do
         include Ruby3NetHTTPConnectable if RUBY_VERSION.to_f > 3.0 # patch #connect method
         include SOCKSProxyDelta::InstanceMethods
@@ -36,6 +34,10 @@ module Net
       end
 
       proxyclass
+    end
+
+    def self.proxyclass
+      @proxyclass ||= Class.new(self).tap { |klass| klass.send(:include, SOCKSProxyDelta) }
     end
 
     class << self

--- a/lib/socksify/http.rb
+++ b/lib/socksify/http.rb
@@ -21,16 +21,20 @@ require_relative 'ruby3net_http_connectable'
 module Net
   # patched class
   class HTTP
-    def self.socks_proxy(p_host, p_port)
+    def self.socks_proxy(p_host, p_port, p_username = nil, p_password = nil)
       proxyclass = Class.new(self)
       proxyclass.send(:include, SOCKSProxyDelta)
       proxyclass.module_eval do
         include Ruby3NetHTTPConnectable if RUBY_VERSION.to_f > 3.0 # patch #connect method
         include SOCKSProxyDelta::InstanceMethods
         extend SOCKSProxyDelta::ClassMethods
+
         @socks_server = p_host
         @socks_port = p_port
+        @socks_username = p_username
+        @socks_password = p_password
       end
+
       proxyclass
     end
 
@@ -41,13 +45,18 @@ module Net
     module SOCKSProxyDelta
       # class methods
       module ClassMethods
-        attr_reader :socks_server, :socks_port
+        attr_reader :socks_server, :socks_port,
+                    :socks_username, :socks_password
       end
 
       # instance methods - no long supports Ruby < 2
       module InstanceMethods
         def address
-          TCPSocket::SOCKSConnectionPeerAddress.new(self.class.socks_server, self.class.socks_port, @address)
+          TCPSocket::SOCKSConnectionPeerAddress.new(
+            self.class.socks_server, self.class.socks_port,
+            @address,
+            self.class.socks_username, self.class.socks_password
+          )
         end
       end
     end

--- a/lib/socksify/socksproxyable.rb
+++ b/lib/socksify/socksproxyable.rb
@@ -48,7 +48,7 @@ module Socksproxyable
         end
 
         auth = "\001"
-        auth += username.to_s.length.chr
+        auth += socks_username.to_s.length.chr
         auth += socks_username.to_s
         auth += socks_password.to_s.length.chr
         auth += socks_password.to_s

--- a/lib/socksify/socksproxyable.rb
+++ b/lib/socksify/socksproxyable.rb
@@ -26,8 +26,8 @@ module Socksproxyable
   # instance method #socks_authenticate
   module InstanceMethodsAuthenticate
     # rubocop:disable Metrics
-    def socks_authenticate
-      if self.class.socks_username || self.class.socks_password
+    def socks_authenticate(socks_username, socks_password)
+      if socks_username || socks_password
         Socksify.debug_debug 'Sending username/password authentication'
         write "\005\001\002"
       else
@@ -42,16 +42,16 @@ module Socksproxyable
         raise SOCKSError, "SOCKS version #{auth_reply[0..0]} not supported"
       end
 
-      if self.class.socks_username || self.class.socks_password
+      if socks_username || socks_password
         if auth_reply[1..1] != "\002"
           raise SOCKSError, "SOCKS authentication method #{auth_reply[1..1]} neither requested nor supported"
         end
 
         auth = "\001"
-        auth += self.class.socks_username.to_s.length.chr
-        auth += self.class.socks_username.to_s
-        auth += self.class.socks_password.to_s.length.chr
-        auth += self.class.socks_password.to_s
+        auth += username.to_s.length.chr
+        auth += socks_username.to_s
+        auth += socks_password.to_s.length.chr
+        auth += socks_password.to_s
         write auth
         auth_reply = recv(2)
         raise SOCKSError, 'SOCKS authentication failed' if auth_reply[1..1] != "\000"

--- a/lib/socksify/tcpsocket.rb
+++ b/lib/socksify/tcpsocket.rb
@@ -10,14 +10,19 @@ class TCPSocket
 
   # See http://tools.ietf.org/html/rfc1928
   # rubocop:disable Metrics/ParameterLists
-  def initialize(host = nil, port = nil, local_host = nil, local_port = nil, **kwargs)
+  def initialize(host = nil, port = nil,
+                 local_host = nil, local_port = nil,
+                 **kwargs)
     socks_peer = host if host.is_a?(SOCKSConnectionPeerAddress)
     socks_server = set_socks_server(socks_peer)
     socks_port = set_socks_port(socks_peer)
+    socks_username = set_socks_username(socks_peer)
+    socks_password = set_socks_password(socks_peer)
     socks_ignores = set_socks_ignores(socks_peer)
     host = socks_peer.peer_host if socks_peer
+
     if socks_server && socks_port && !socks_ignores.include?(host)
-      make_socks_connection(host, port, socks_server, socks_port, **kwargs)
+      make_socks_connection(host, port, socks_server, socks_port, socks_username, socks_password, **kwargs)
     else
       make_direct_connection(host, port, local_host, local_port, **kwargs)
     end
@@ -26,11 +31,13 @@ class TCPSocket
 
   # string representation of the peer host address
   class SOCKSConnectionPeerAddress < String
-    attr_reader :socks_server, :socks_port
+    attr_reader :socks_server, :socks_port, :socks_username, :socks_password
 
-    def initialize(socks_server, socks_port, peer_host)
+    def initialize(socks_server, socks_port, peer_host, socks_username = nil, socks_password = nil)
       @socks_server = socks_server
       @socks_port = socks_port
+      @socks_username = socks_username
+      @socks_password = socks_password
       super(peer_host)
     end
 
@@ -53,14 +60,25 @@ class TCPSocket
     socks_peer ? socks_peer.socks_port : self.class.socks_port
   end
 
+  def set_socks_username(socks_peer = nil)
+    socks_peer ? socks_peer.socks_username : self.class.socks_username
+  end
+
+  def set_socks_password(socks_peer = nil)
+    socks_peer ? socks_peer.socks_password : self.class.socks_password
+  end
+
   def set_socks_ignores(socks_peer = nil)
     socks_peer ? [] : self.class.socks_ignores
   end
 
-  def make_socks_connection(host, port, socks_server, socks_port, **kwargs)
+  def make_socks_connection(host, port,
+                            socks_server, socks_port,
+                            socks_username, socks_password,
+                            **kwargs)
     Socksify.debug_notice "Connecting to SOCKS server #{socks_server}:#{socks_port}"
     initialize_tcp socks_server, socks_port, **kwargs
-    socks_authenticate unless @socks_version =~ /^4/
+    socks_authenticate(socks_username, socks_password) unless @socks_version =~ /^4/
     socks_connect(host, port) if host
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,6 +26,10 @@ module HelperMethods
     Net::HTTP.socks_proxy('127.0.0.1', 9050)
   end
 
+  def http_tor_proxy_with_auth(username, password)
+    Net::HTTP.socks_proxy('127.0.0.1', 1080, username, password)
+  end
+
   def get_http(http_klass, url, host_header = nil)
     uri = URI(url)
     body = nil

--- a/test/test_socksify_legacy.rb
+++ b/test/test_socksify_legacy.rb
@@ -1,0 +1,38 @@
+module TestSocksifyLegacy
+  if RUBY_VERSION.to_f < 3.1 # test legacy methods TCPSocket.socks_server= and TCPSocket.socks_port=
+    def test_check_tor
+      disable_socks
+      is_tor_direct, ip_direct = check_tor
+
+      refute is_tor_direct
+
+      enable_socks
+      is_tor_socks, ip_socks = check_tor
+
+      assert is_tor_socks
+      refute_equal ip_direct, ip_socks
+    end
+
+    def test_check_tor_with_service_as_a_string
+      disable_socks
+      is_tor_direct, ip_direct = check_tor_with_service_as_string
+
+      refute is_tor_direct
+      enable_socks
+      is_tor_socks, ip_socks = check_tor_with_service_as_string
+
+      assert is_tor_socks
+
+      refute_equal ip_direct, ip_socks
+    end
+
+    def test_connect_to_ip
+      disable_socks
+      ip_direct = internet_yandex_com_ip
+      enable_socks
+      ip_socks = internet_yandex_com_ip
+
+      refute_equal ip_direct, ip_socks
+    end
+  end
+end


### PR DESCRIPTION
I did some refactoring to pass rubocop fails and add new development dependency for socks5 proxy with auth because tor which currently is used  for development doesn't support login/password auth

I double checked CI in my fork and it's green. 

https://github.com/anton-smagin/socksify-ruby/pull/1/checks